### PR TITLE
feat: Allow users to name connections to disambiguate them

### DIFF
--- a/src/components/ConnectionCard.tsx
+++ b/src/components/ConnectionCard.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, Intent } from "@blueprintjs/core"
+import { Button, Card, Intent, H4 } from "@blueprintjs/core"
 import { Connection } from "../config"
 import { useState } from "react"
 import ConfirmDialog from "./ConfirmDialog"
@@ -13,9 +13,12 @@ type Props = {
 export default function ConnectionCard({connection, viewer, onDelete}: Props) {
     const [isDeleting, setDeleting] = useState(false)
     return (
-        <>  
+        <>
             <Card className="flex">
                 <div className="grow">
+                    {connection.name != null && (
+                        <H4>{connection.name}</H4>
+                    )}
                     <span><b>Host:</b> <a href={`https://${connection.host}`}>{connection.host}</a></span>
                     {viewer !== undefined && <span className="ml-4"><b>User: </b>{viewer.login}</span>}
                 </div>

--- a/src/components/ConnectionDialog.tsx
+++ b/src/components/ConnectionDialog.tsx
@@ -9,11 +9,13 @@ export type Props = {
     onSubmit: (connection: Connection) => void,
 }
 
-export default function ConnectionDialog({isOpen, onClose, onSubmit}: Props) {    
+export default function ConnectionDialog({isOpen, onClose, onSubmit}: Props) {
+    const [name, setName] = useState<string | undefined>(undefined)
     const [baseUrl, setBaseUrl] = useState("")
     const [auth, setAuth] = useState("")
 
     const handleOpening = () => {
+        setName(undefined)
         setBaseUrl("")
         setAuth("")
     }
@@ -21,7 +23,7 @@ export default function ConnectionDialog({isOpen, onClose, onSubmit}: Props) {
         if (isValid()) {
             const url = new URL(baseUrl)
             const host = (url.hostname == "api.github.com") ? "github.com" : url.hostname
-            onSubmit({baseUrl, host, auth})
+            onSubmit({name, baseUrl, host, auth})
             onClose()
         }
     }
@@ -31,6 +33,11 @@ export default function ConnectionDialog({isOpen, onClose, onSubmit}: Props) {
         <>
             <Dialog title="New connection" isOpen={isOpen} onClose={onClose} onOpening={handleOpening}>
                 <DialogBody>
+                    <FormGroup label="Connection Name">
+                        <InputGroup
+                            value={name ?? ""}
+                            onChange={e => setName(e.target.value)} />
+                    </FormGroup>
                     <FormGroup label="Base URL" labelInfo="(required)">
                         <InputGroup
                             value={baseUrl}

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ export type Config = {
     sections: Section[],
     connections: Connection[],
 }
-  
+
 export type Section = {
     label: string,
     search: string,
@@ -13,6 +13,7 @@ export type Section = {
 }
 
 export type Connection = {
+    name?: string,
     host: string,
     baseUrl: string,
     auth: string,


### PR DESCRIPTION
Just a proposal to allow naming connections. I setup two tokens:

1. A connection with a token that has access to my personal profile
2. A connection with a token that has access to an organization

Unfortunately, token introspection is very limited for github so `viewer` just gets the authenticated user which would be `glossawy` in both cases so the connections look identical. This is extremely simple in just adding an optional name field with no real validation, I don't think it needs to be fancy.

I don't see any way of getting the user the token grants access to with github's existing REST or GraphQL API.


Before: 
![image](https://github.com/pvcnt/reviewer/assets/4606234/95869081-edfe-4fd0-a023-5752f0a9ce0b)

After:
![image](https://github.com/pvcnt/reviewer/assets/4606234/89068ec2-e473-4566-8a63-e67011218e73)

