### PR TITLE
fix: Handle multiple connections correctly on dashboard

### DIFF
--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -30,7 +30,7 @@ export default function Dashboard() {
     const results = useQueries({
         queries: config.sections.flatMap(section => {
             return config.connections.map((connection, idx) => ({
-                queryKey: ['pulls', connection.host, section.search],
+                queryKey: ['pulls', connection.host, connection.auth, section.search],
                 queryFn: () => getPulls(connection, section.search, viewers[idx].data?.login || ""),
                 refetchInterval: 60000,
                 refetchIntervalInBackground: true,


### PR DESCRIPTION
`react-query`'s built-in memoization was causing connections to the same domain to clobber each other. You would have a race condition on which set of data gets shown and it would show up twice.

The goal here is to allow multiple connections to be used and have the sum of all of their PR requests be shown in the dashboard. Since we are already storing the key plain in `localStorage` I don't immediately see an issue with utilizing the token as part of the react query key. 

Though technically it does expose the access token to more libraries. If that's a concern we could hash the token.